### PR TITLE
Support knx dpt

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "knx.js",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": false,
   "repository": {
     "type": "git",

--- a/src/KnxData.js
+++ b/src/KnxData.js
@@ -88,4 +88,24 @@ KnxData.prototype.asDpt9 = function () {
     return KnxHelper.ldexp((0.01*mantissa), exponent);
 };
 
+/// <summary>
+///     Interpret the underlying data as 4 byte signed integer
+/// </summary>
+/// <returns></returns>
+KnxData.prototype.asDpt13 = function () {
+    view = this.dataView();
+    //return this.apdu.length;
+    return view.getInt32(0);
+};
+
+/// <summary>
+///     Interpret the underlying data as 4 byte floating point number
+/// </summary>
+/// <returns></returns>
+KnxData.prototype.asDpt14 = function () {
+    view = this.dataView();
+    //return this.apdu.length;
+    return view.getFloat32(0);
+};
+
 module.exports = KnxData;

--- a/src/KnxData.js
+++ b/src/KnxData.js
@@ -65,4 +65,17 @@ KnxData.prototype.asDpt1 = function () {
     return (view.getUint8(0) != 0);
 };
 
+/// <summary>
+///     Interpret the underlying data as 2 byte floating point value
+/// </summary>
+/// <returns></returns>
+KnxData.prototype.asDpt9 = function () {
+    var sign     =  this.data[0] >> 7;
+    var exponent = (this.data[0] & 0b01111000) >> 3;
+    var mantissa = 256 * (this.data[0] & 0b00000111) + this.data[1];
+    mantissa = (sign == 1) ? ~(mantissa^2047) : mantissa;
+
+    return KnxHelper.ldexp((0.01*mantissa), exponent);
+};
+
 module.exports = KnxData;

--- a/src/KnxData.js
+++ b/src/KnxData.js
@@ -2,10 +2,10 @@
  * Created by aborovsky on 24.08.2015.
  */
 
-function KnxData(data) {
+function KnxData(apdu) {
 
     this.ClassName = 'KnxData';
-    this.data = data;
+    this.apdu = apdu;
 }
 
 /// <summary>
@@ -48,10 +48,10 @@ function KnxData(data) {
 /// <returns>DataView object</returns>
 KnxData.prototype.dataView = function () {
     var i;
-    this.buffer = new ArrayBuffer(this.data.length);
+    this.buffer = new ArrayBuffer(this.apdu.length-2);
     dataView = new DataView(this.buffer);
-    for(i = 0; i < this.data.length; i++) {
-        dataView.setUint8(i, this.data[i]);
+    for(i = 0; i < this.buffer.length; i++) {
+        dataView.setUint8(i, this.apdu[i+2]);
     }
     return dataView;
 };
@@ -61,8 +61,17 @@ KnxData.prototype.dataView = function () {
 /// </summary>
 /// <returns></returns>
 KnxData.prototype.asDpt1 = function () {
+    var data = 0x3F & this.apdu[1]
+    return (data != 0);
+};
+
+/// <summary>
+///     Interpret the underlying data as boolean value
+/// </summary>
+/// <returns></returns>
+KnxData.prototype.asDpt5 = function () {
     view = this.dataView();
-    return (view.getUint8(0) != 0);
+    return view.getUint8(0);
 };
 
 /// <summary>
@@ -70,9 +79,9 @@ KnxData.prototype.asDpt1 = function () {
 /// </summary>
 /// <returns></returns>
 KnxData.prototype.asDpt9 = function () {
-    var sign     =  this.data[0] >> 7;
-    var exponent = (this.data[0] & 0b01111000) >> 3;
-    var mantissa = 256 * (this.data[0] & 0b00000111) + this.data[1];
+    var sign     =  this.apdu[2] >> 7;
+    var exponent = (this.apdu[2] & 0b01111000) >> 3;
+    var mantissa = 256 * (this.apdu[2] & 0b00000111) + this.apdu[3];
     mantissa = (sign == 1) ? ~(mantissa^2047) : mantissa;
 
     return KnxHelper.ldexp((0.01*mantissa), exponent);

--- a/src/KnxData.js
+++ b/src/KnxData.js
@@ -48,9 +48,10 @@ function KnxData(apdu) {
 /// <returns>DataView object</returns>
 KnxData.prototype.dataView = function () {
     var i;
-    this.buffer = new ArrayBuffer(this.apdu.length-2);
+    var len = this.apdu.length - 2;
+    this.buffer = new ArrayBuffer(len);
     dataView = new DataView(this.buffer);
-    for(i = 0; i < this.buffer.length; i++) {
+    for(i = 0; i < len; i++) {
         dataView.setUint8(i, this.apdu[i+2]);
     }
     return dataView;

--- a/src/KnxData.js
+++ b/src/KnxData.js
@@ -66,7 +66,7 @@ KnxData.prototype.asDpt1 = function () {
 };
 
 /// <summary>
-///     Interpret the underlying data as boolean value
+///     Interpret the underlying data as 1 Byte unsigned value
 /// </summary>
 /// <returns></returns>
 KnxData.prototype.asDpt5 = function () {

--- a/src/KnxData.js
+++ b/src/KnxData.js
@@ -1,0 +1,68 @@
+/**
+ * Created by aborovsky on 24.08.2015.
+ */
+
+function KnxData(data) {
+
+    this.ClassName = 'KnxData';
+    this.data = data;
+}
+
+/// <summary>
+///    Represent data send over knx bus and provide methods to interpret them as different dpt values
+/// </summary>
+/// <param name="data">Byte array value or integer</param>
+/*
+ Datatypes
+
+ KNX/EIB Function                   Information length      EIS         DPT     Value
+ Switch                             1 Bit                   EIS 1       DPT 1	0,1
+ Dimming (Position, Control, Value) 1 Bit, 4 Bit, 8 Bit     EIS 2	    DPT 3	[0,0]...[1,7]
+ Time                               3 Byte                  EIS 3	    DPT 10
+ Date                               3 Byte                  EIS 4       DPT 11
+ Floating point                     2 Byte                  EIS 5	    DPT 9	-671088,64 - 670760,96
+ 8-bit unsigned value               1 Byte                  EIS 6	    DPT 5	0...255
+ 8-bit unsigned value               1 Byte                  DPT 5.001	DPT 5.001	0...100
+ Blinds / Roller shutter            1 Bit                   EIS 7	    DPT 1	0,1
+ Priority                           2 Bit                   EIS 8	    DPT 2	[0,0]...[1,1]
+ IEEE Floating point                4 Byte                  EIS 9	    DPT 14	4-Octet Float Value IEEE 754
+ 16-bit unsigned value              2 Byte                  EIS 10	    DPT 7	0...65535
+ 16-bit signed value                2 Byte                  DPT 8	    DPT 8	-32768...32767
+ 32-bit unsigned value              4 Byte                  EIS 11	    DPT 12	0...4294967295
+ 32-bit signed value                4 Byte                  DPT 13	    DPT 13	-2147483648...2147483647
+ Access control                     1 Byte                  EIS 12	    DPT 15
+ ASCII character                    1 Byte                  EIS 13	    DPT 4
+ 8859_1 character                   1 Byte                  DPT 4.002	DPT 4.002
+ 8-bit signed value                 1 Byte                  EIS 14	    DPT 6	-128...127
+ 14 character ASCII                 14 Byte                 EIS 15	    DPT 16
+ 14 character 8859_1                14 Byte                 DPT 16.001	DPT 16.001
+ Scene                              1 Byte                  DPT 17	    DPT 17	0...63
+ HVAC                               1 Byte                  DPT 20	    DPT 20	0..255
+ Unlimited string 8859_1            .                       DPT 24	    DPT 24
+ List 3-byte value                  3 Byte                  DPT 232	    DPT 232	RGB[0,0,0]...[255,255,255]
+ */
+
+/// <summary>
+///     Prepare the internal data to access it as specific type
+/// </summary>
+/// <returns>DataView object</returns>
+KnxData.prototype.dataView = function () {
+    var i;
+    this.buffer = new ArrayBuffer(this.data.length);
+    dataView = new DataView(this.buffer);
+    for(i = 0; i < this.data.length; i++) {
+        dataView.setUint8(i, this.data[i]);
+    }
+    return dataView;
+};
+
+/// <summary>
+///     Interpret the underlying data as boolean value
+/// </summary>
+/// <returns></returns>
+KnxData.prototype.asDpt1 = function () {
+    view = this.dataView();
+    return (view.getUint8(0) != 0);
+};
+
+module.exports = KnxData;

--- a/src/KnxHelper.js
+++ b/src/KnxHelper.js
@@ -285,7 +285,7 @@ KnxHelper.GetData = function (dataLength, apdu /*buffer*/) {
         default:
             var data = new Buffer(apdu.length);
             //TODO: originally, here is utf code to char convert (String.fromCharCode).
-            apdu[i].copy(data);
+            apdu.copy(data);
             return data;
     }
 }

--- a/src/KnxReceiver.js
+++ b/src/KnxReceiver.js
@@ -101,8 +101,7 @@ KnxReceiver.prototype.ProcessCEMI = function (/*KnxDatagram*/ datagram, /*buffer
             datagram.apdu[i] = cemi[9 + i + datagram.additional_info_length];
 
         datagram.data = KnxHelper.GetData(datagram.data_length, datagram.apdu);
-        datagram.dptData = new KnxData(datagram.apdu.subarray(2));
-        datagram.raw_data = datagram.apdu
+        datagram.dptData = new KnxData(datagram.apdu);
 
         if (this.connection.debug) {
             console.log("-----------------------------------------------------------------------------------------------------");
@@ -136,11 +135,11 @@ KnxReceiver.prototype.ProcessCEMI = function (/*KnxDatagram*/ datagram, /*buffer
         switch (type) {
             case 8:
                 this.connection.emit('event', datagram.destination_address, datagram.data, datagram);
-                this.connection.emit('event.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram, datagram.raw_data);
+                this.connection.emit('event.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram);
                 break;
             case 4:
                 this.connection.emit('status', datagram.destination_address, datagram.data, datagram);
-                this.connection.emit('status.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram, datagram.raw_data);
+                this.connection.emit('status.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram);
                 break;
             default:
                 console.log('Unknown type[' + type + '] received in datagram[' + datagram.data.toString('hex') + ']');

--- a/src/KnxReceiver.js
+++ b/src/KnxReceiver.js
@@ -1,6 +1,9 @@
 /**
  * Created by aborovsky on 26.08.2015.
  */
+
+var KnxData = require('./KnxData');
+
 function KnxReceiver(/*KnxConnection*/ connection) {
     this.connection = connection;
 }
@@ -98,6 +101,7 @@ KnxReceiver.prototype.ProcessCEMI = function (/*KnxDatagram*/ datagram, /*buffer
             datagram.apdu[i] = cemi[9 + i + datagram.additional_info_length];
 
         datagram.data = KnxHelper.GetData(datagram.data_length, datagram.apdu);
+        datagram.dptData = new KnxData(datagram.apdu.subarray(2));
         datagram.raw_data = datagram.apdu
 
         if (this.connection.debug) {

--- a/src/KnxReceiver.js
+++ b/src/KnxReceiver.js
@@ -98,6 +98,7 @@ KnxReceiver.prototype.ProcessCEMI = function (/*KnxDatagram*/ datagram, /*buffer
             datagram.apdu[i] = cemi[9 + i + datagram.additional_info_length];
 
         datagram.data = KnxHelper.GetData(datagram.data_length, datagram.apdu);
+        datagram.raw_data = datagram.apdu
 
         if (this.connection.debug) {
             console.log("-----------------------------------------------------------------------------------------------------");
@@ -131,11 +132,11 @@ KnxReceiver.prototype.ProcessCEMI = function (/*KnxDatagram*/ datagram, /*buffer
         switch (type) {
             case 8:
                 this.connection.emit('event', datagram.destination_address, datagram.data, datagram);
-                this.connection.emit('event.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram);
+                this.connection.emit('event.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram, datagram.raw_data);
                 break;
             case 4:
                 this.connection.emit('status', datagram.destination_address, datagram.data, datagram);
-                this.connection.emit('status.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram);
+                this.connection.emit('status.' + datagram.destination_address.toString(), datagram.destination_address, datagram.data, datagram, datagram.raw_data);
                 break;
             default:
                 console.log('Unknown type[' + type + '] received in datagram[' + datagram.data.toString('hex') + ']');


### PR DESCRIPTION
Hello,
i am using your library in connection with node-red-contrib-knx to access my lights and further devices in my home from a small home server.
When i tried to implement a sensor for my power consumption i experienced some problems cause there were no 4 byte datapoints implemented. Furthermore i noticed that the lib relies only on the data length to determine the data type. I think this is not a good idea as it can be interpreted as a float number or a integer value depending on the specific system.

So finally i added a class where the user of the library can decide how the data should be interpreted.

I would really like to see something like this in your library as it may be helpful for others to.